### PR TITLE
Add class abstractness checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Build fragments
+build
+build-*
+cmake-build-*
+*.o
+*.a
+*.lib
+*.so
+*.dll
+
+# Desktop/IDE related files
+CMakeLists.txt.user

--- a/include/cppast/cpp_class.hpp
+++ b/include/cppast/cpp_class.hpp
@@ -128,8 +128,8 @@ public:
     {
     public:
         /// \effects Sets the name and kind and whether it is `final`.
-        explicit builder(std::string name, cpp_class_kind kind, bool is_final = false)
-        : class_(new cpp_class(std::move(name), kind, is_final))
+		explicit builder(std::string name, cpp_class_kind kind, bool is_final = false, bool is_abstract = false)
+		: class_(new cpp_class(std::move(name), kind, is_final, is_abstract))
         {}
 
         /// \effects Marks the class as final.
@@ -137,6 +137,12 @@ public:
         {
             class_->final_ = true;
         }
+
+		/// \effects Marks the class as abstract.
+		void is_abstract() noexcept
+		{
+			class_->abstract_ = true;
+		}
 
         /// \effects Builds a [cppast::cpp_base_class]() and adds it.
         cpp_base_class& base_class(std::string name, std::unique_ptr<cpp_type> type,
@@ -207,6 +213,12 @@ public:
         return final_;
     }
 
+	/// \returns Whether or not the class contains a pure virtual function.
+	bool is_abstract() const noexcept
+	{
+		return abstract_;
+	}
+
     /// \returns An iteratable object iterating over the [cppast::cpp_base_class]() specifiers.
     detail::iteratable_intrusive_list<cpp_base_class> bases() const noexcept
     {
@@ -214,8 +226,8 @@ public:
     }
 
 private:
-    cpp_class(std::string name, cpp_class_kind kind, bool final)
-    : cpp_entity(std::move(name)), kind_(kind), final_(final)
+	cpp_class(std::string name, cpp_class_kind kind, bool final, bool abstract)
+	: cpp_entity(std::move(name)), kind_(kind), final_(final), abstract_(abstract)
     {}
 
     cpp_entity_kind do_get_entity_kind() const noexcept override;
@@ -228,6 +240,7 @@ private:
     detail::intrusive_list<cpp_base_class> bases_;
     cpp_class_kind                         kind_;
     bool                                   final_;
+	bool                                   abstract_;
 };
 
 /// \returns The type the base class refers to.

--- a/src/libclang/class_parser.cpp
+++ b/src/libclang/class_parser.cpp
@@ -119,9 +119,6 @@ std::unique_ptr<cpp_entity> detail::parse_cpp_class(const detail::parse_context&
     auto is_templated = (clang_getTemplateCursorKind(cur) != CXCursor_NoDeclFound
                          || !clang_Cursor_isNull(clang_getSpecializedCursorTemplate(cur)));
     auto is_friend    = clang_getCursorKind(parent_cur) == CXCursor_FriendDecl;
-
-
-
 	auto is_abstract  = clang_CXXRecord_isAbstract(cur);
 
     auto                                builder = make_class_builder(context, cur);

--- a/src/libclang/class_parser.cpp
+++ b/src/libclang/class_parser.cpp
@@ -120,6 +120,10 @@ std::unique_ptr<cpp_entity> detail::parse_cpp_class(const detail::parse_context&
                          || !clang_Cursor_isNull(clang_getSpecializedCursorTemplate(cur)));
     auto is_friend    = clang_getCursorKind(parent_cur) == CXCursor_FriendDecl;
 
+
+
+	auto is_abstract  = clang_CXXRecord_isAbstract(cur);
+
     auto                                builder = make_class_builder(context, cur);
     type_safe::optional<cpp_entity_ref> semantic_parent;
     if (!is_friend)
@@ -169,6 +173,11 @@ std::unique_ptr<cpp_entity> detail::parse_cpp_class(const detail::parse_context&
                 builder.add_child(std::move(entity));
         });
     }
+
+	if(is_abstract)
+	{
+		builder.is_abstract();
+	}
 
     if (!is_friend && clang_isCursorDefinition(cur))
         return is_templated

--- a/test/cpp_class.cpp
+++ b/test/cpp_class.cpp
@@ -68,6 +68,17 @@ protected:
 class e
 : a, private d {};
 
+// abstract classes
+/// struct h{
+///   virtual void z()=0;
+/// };
+struct h{ virtual void z() = 0; };
+
+/// struct i
+/// :h{
+/// };
+struct i: h{};
+
 namespace ns
 {
     /// struct base;
@@ -101,6 +112,7 @@ struct g
         {
             REQUIRE(c.class_kind() == cpp_class_kind::struct_t);
             REQUIRE(!c.is_final());
+			REQUIRE(!c.is_abstract());
             REQUIRE(c.bases().begin() == c.bases().end());
             REQUIRE(c.begin() == c.end());
 
@@ -115,8 +127,11 @@ struct g
             REQUIRE(c.begin() == c.end());
 
             if (c.is_definition())
+			{
                 REQUIRE(c.is_final());
-            else
+				REQUIRE(!c.is_abstract());
+			}
+			else
                 REQUIRE(c.is_declaration());
 
             auto definition = get_definition(idx, c);
@@ -129,6 +144,7 @@ struct g
             REQUIRE(!c.is_definition());
             REQUIRE(c.class_kind() == cpp_class_kind::struct_t);
             REQUIRE(!c.is_final());
+			REQUIRE(!c.is_abstract());
             REQUIRE(c.bases().begin() == c.bases().end());
             REQUIRE(c.begin() == c.end());
 
@@ -141,6 +157,7 @@ struct g
             REQUIRE(!c.is_declaration());
             REQUIRE(c.class_kind() == cpp_class_kind::union_t);
             REQUIRE(!c.is_final());
+			REQUIRE(!c.is_abstract());
             REQUIRE(c.bases().begin() == c.bases().end());
             REQUIRE(c.begin() == c.end());
         }
@@ -150,6 +167,7 @@ struct g
             REQUIRE(!c.is_declaration());
             REQUIRE(c.class_kind() == cpp_class_kind::struct_t);
             REQUIRE(!c.is_final());
+			REQUIRE(!c.is_abstract());
             REQUIRE(c.bases().begin() == c.bases().end());
 
             auto no_children = 0u;
@@ -206,6 +224,7 @@ struct g
             REQUIRE(!c.is_declaration());
             REQUIRE(c.class_kind() == cpp_class_kind::class_t);
             REQUIRE(!c.is_final());
+			REQUIRE(!c.is_abstract());
             REQUIRE(c.begin() == c.end());
 
             auto no_bases = 0u;
@@ -241,6 +260,7 @@ struct g
             REQUIRE(!c.is_declaration());
             REQUIRE(c.class_kind() == cpp_class_kind::struct_t);
             REQUIRE(!c.is_final());
+			REQUIRE(!c.is_abstract());
             REQUIRE(c.begin() == c.end());
 
             auto no_bases = 0u;
@@ -276,6 +296,7 @@ struct g
             REQUIRE(!c.is_declaration());
             REQUIRE(c.class_kind() == cpp_class_kind::struct_t);
             REQUIRE(!c.is_final());
+			REQUIRE(!c.is_abstract());
             REQUIRE(c.begin() == c.end());
 
             auto no_bases = 0u;
@@ -296,8 +317,24 @@ struct g
             }
             REQUIRE(no_bases == 1u);
         }
+		else if (c.name() == "h")
+		{
+			REQUIRE(c.is_definition());
+			REQUIRE(!c.is_declaration());
+			REQUIRE(c.class_kind() == cpp_class_kind::struct_t);
+			REQUIRE(!c.is_final());
+			REQUIRE(c.is_abstract());
+		}
+		else if (c.name() == "i")
+		{
+			REQUIRE(c.is_definition());
+			REQUIRE(!c.is_declaration());
+			REQUIRE(c.class_kind() == cpp_class_kind::struct_t);
+			REQUIRE(!c.is_final());
+			REQUIRE(c.is_abstract());
+		}
         else
             REQUIRE(false);
     });
-    REQUIRE(count == 12u);
+	REQUIRE(count == 14u);
 }


### PR DESCRIPTION
A pretty simple feature to add that is already supported by libclang with `clang_CXXRecord_isAbstract`.