### PR TITLE
build cppast with bazel

### DIFF
--- a/bazel/.gitignore
+++ b/bazel/.gitignore
@@ -1,0 +1,4 @@
+bazel-bazel
+bazel-bin
+bazel-out
+bazel-testlogs

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,0 +1,1 @@
+package(default_visibility = ["//visibility:public"])

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -1,0 +1,4 @@
+To build with bazel:
+```
+bazelisk build @cppast//:cppast
+```

--- a/bazel/WORKSPACE
+++ b/bazel/WORKSPACE
@@ -1,0 +1,29 @@
+
+load("//deps/toolchain:get.bzl", "toolchain")
+load("//deps/bazel_skylib:get.bzl", "bazelSkylib")
+load("//deps/aspect_bazel_lib:get.bzl", "aspectBazelLib")
+load("//deps/type_safe:get.bzl", "typeSafe")
+load("//deps/cppast:get.bzl", "cppast")
+
+toolchain()
+bazelSkylib()
+aspectBazelLib()
+typeSafe()
+cppast()
+
+
+# Pull in a hermetic clang toolchain.  This is where we will also source libclang for cppast.
+load("@com_grail_bazel_toolchain//toolchain:deps.bzl", "bazel_toolchain_dependencies")
+
+bazel_toolchain_dependencies()
+
+load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
+
+llvm_toolchain(
+    name = "llvm_toolchain",
+    llvm_version = "11.0.0",
+)
+
+load("@llvm_toolchain//:toolchains.bzl", "llvm_register_toolchains")
+
+llvm_register_toolchains()

--- a/bazel/deps/BUILD
+++ b/bazel/deps/BUILD
@@ -1,0 +1,1 @@
+package(default_visibility = ["//visibility:public"])

--- a/bazel/deps/aspect_bazel_lib/BUILD
+++ b/bazel/deps/aspect_bazel_lib/BUILD
@@ -1,0 +1,1 @@
+package(default_visibility = ["//visibility:public"])

--- a/bazel/deps/aspect_bazel_lib/get.bzl
+++ b/bazel/deps/aspect_bazel_lib/get.bzl
@@ -1,0 +1,11 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def aspectBazelLib():
+    http_archive(
+        name="aspect_bazel_lib" ,
+        sha256="ca7cd1463ad994778b212ba704a8144c9a27c638e11480e859897e9f65e6496f" ,
+        strip_prefix="bazel-lib-b1ee3675f28cc7089fb34b305d5ae09e77b76deb" ,
+        urls = [
+            "https://github.com/aspect-build/bazel-lib/archive/b1ee3675f28cc7089fb34b305d5ae09e77b76deb.tar.gz"
+        ],
+    )

--- a/bazel/deps/bazel_skylib/BUILD
+++ b/bazel/deps/bazel_skylib/BUILD
@@ -1,0 +1,1 @@
+package(default_visibility = ["//visibility:public"])

--- a/bazel/deps/bazel_skylib/get.bzl
+++ b/bazel/deps/bazel_skylib/get.bzl
@@ -1,0 +1,12 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def bazelSkylib():
+    http_archive(
+        name="bazel_skylib",
+        sha256="d007737f4508c8fb9e5de09c33346cb5971f6f4a629210e4619c20a785452fd7" ,
+        strip_prefix="bazel-skylib-2a89db4749d1aa860ea42ab50491cdc40d9a199a" ,
+        urls = [
+            "https://github.com/bazelbuild/bazel-skylib/archive/d007737f4508c8fb9e5de09c33346cb5971f6f4a629210e4619c20a785452fd7.tar.gz"
+        ],
+    )
+

--- a/bazel/deps/cppast/BUILD
+++ b/bazel/deps/cppast/BUILD
@@ -1,0 +1,1 @@
+package(default_visibility = ["//visibility:public"])

--- a/bazel/deps/cppast/build.BUILD
+++ b/bazel/deps/cppast/build.BUILD
@@ -1,0 +1,60 @@
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+
+package(default_visibility = ["//visibility:public"])
+
+# Copy the LLVM clang-c files needed by cppast out of the llvm_toolchain and into this BUILD.
+copy_file(name = "clang_Index",
+          src = "@llvm_toolchain//:include/clang-c/Index.h",
+          out = "Index.h"
+)
+copy_file(name = "clang_BuildSystem",
+          src = "@llvm_toolchain//:include/clang-c/BuildSystem.h",
+          out = "BuildSystem.h"
+)
+copy_file(name = "clang_CXErrorCode",
+          src = "@llvm_toolchain//:include/clang-c/CXErrorCode.h",
+          out = "CXErrorCode.h"
+)
+copy_file(name = "clang_ExternC",
+          src = "@llvm_toolchain//:include/clang-c/ExternC.h",
+          out = "ExternC.h"
+)
+copy_file(name = "clang_Platform",
+          src = "@llvm_toolchain//:include/clang-c/Platform.h",
+          out = "Platform.h"
+)
+copy_file(name = "clang_CXString",
+          src = "@llvm_toolchain//:include/clang-c/CXString.h",
+          out = "CXString.h"
+)
+copy_file(name = "clang_CXCompilationDatabase",
+          src = "@llvm_toolchain//:include/clang-c/CXCompilationDatabase.h",
+          out = "CXCompilationDatabase.h"
+)
+
+# Build all the of third party code needed by cppast.
+cc_library(name = "third_party_deps",
+           hdrs = ["Index.h","BuildSystem.h","CXErrorCode.h","ExternC.h","Platform.h", "CXString.h", "CXCompilationDatabase.h"],
+           srcs = ["@llvm_toolchain//:lib"],
+           includes = ["."],
+           include_prefix = "clang-c",
+           deps = [
+            "@type_safe",
+           ]
+)
+
+cc_library(
+    name = "cppast",
+    hdrs = glob(["include/**/*.hpp"]) + glob(["src/**/*.hpp"]) + glob(["external/**/*.hpp"]),
+    srcs = glob(["src/**/*.cpp"]) + glob(["external/**/*.cpp"], exclude = ["external/tpl/process_win.cpp"]),
+    includes = [".","include","src","src/libclang", "external/tpl"],
+    copts = [
+        "-DCPPAST_CLANG_BINARY='\"/bin/clang\"'",
+        "-DCPPAST_VERSION_MAJOR='\"\"'",
+        "-DCPPAST_VERSION_MINOR='\"\"'"
+    ],
+    deps = [
+        ":third_party_deps"
+    ]
+)
+

--- a/bazel/deps/cppast/get.bzl
+++ b/bazel/deps/cppast/get.bzl
@@ -1,0 +1,13 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def cppast():
+    http_archive(
+        name="cppast" ,
+        build_file="//deps/cppast:build.BUILD" ,
+        sha256="b89ed1578880ccd17f1cd30486a75454ebe33e6c75f9166ecd9531efc63dec8a" ,
+        strip_prefix="cppast-4143cea00f9ac2c8f2dc71f20cc52cc3370286c9" ,
+        urls = [
+            "https://github.com/foonathan/cppast/archive/4143cea00f9ac2c8f2dc71f20cc52cc3370286c9.tar.gz"
+        ],
+    )
+

--- a/bazel/deps/toolchain/BUILD
+++ b/bazel/deps/toolchain/BUILD
@@ -1,0 +1,1 @@
+package(default_visibility = ["//visibility:public"])

--- a/bazel/deps/toolchain/get.bzl
+++ b/bazel/deps/toolchain/get.bzl
@@ -1,0 +1,18 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def toolchain():
+    http_archive(
+        name="com_grail_bazel_toolchain" ,
+        sha256="6bf2b30c8ab190eee44e1843f0cff457a5379250ad8239155dcf5bd38e4cc70f" ,
+        strip_prefix="bazel-toolchain-f2d1ba2c9d713b2aa6e7063f6d11dd3d64aa402a" ,
+        urls = [
+            "https://github.com/Unilang/grailbio/archive/f2d1ba2c9d713b2aa6e7063f6d11dd3d64aa402a.tar.gz"
+        ],
+        patches = [
+            "//deps/toolchain:p1.patch",
+        ],
+        patch_args = [
+            "-p1",
+        ],
+    )
+

--- a/bazel/deps/toolchain/p1.patch
+++ b/bazel/deps/toolchain/p1.patch
@@ -1,0 +1,21 @@
+diff --git a/toolchain/BUILD.tpl b/toolchain/BUILD.tpl
+index bc9280f..07fd98c 100644
+--- a/toolchain/BUILD.tpl
++++ b/toolchain/BUILD.tpl
+@@ -19,7 +19,7 @@ load("@rules_cc//cc:defs.bzl", "cc_toolchain_suite")
+ exports_files(["Makevars"])
+ 
+ # Some targets may need to directly depend on these files.
+-exports_files(glob(["bin/*", "lib/*"]))
++exports_files(glob(["bin/*", "lib/*", "include/*"]))
+ 
+ filegroup(
+     name = "empty",
+@@ -116,6 +116,7 @@ filegroup(
+     name = "include",
+     srcs = glob([
+         "include/c++/**",
++        "include/clang-c/**",
+         "lib/clang/%{llvm_version}/include/**",
+     ]),
+ )

--- a/bazel/deps/type_safe/BUILD
+++ b/bazel/deps/type_safe/BUILD
@@ -1,0 +1,1 @@
+package(default_visibility = ["//visibility:public"])

--- a/bazel/deps/type_safe/build.BUILD
+++ b/bazel/deps/type_safe/build.BUILD
@@ -1,0 +1,12 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "type_safe",
+    hdrs = glob(["include/**/*.hpp"]) + glob(["external/**/*.hpp"]),
+    includes = ["include","external/debug_assert"],
+    visibility = ["//visibility:public"],
+)
+
+

--- a/bazel/deps/type_safe/get.bzl
+++ b/bazel/deps/type_safe/get.bzl
@@ -1,0 +1,13 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def typeSafe():
+    http_archive(
+        name="type_safe" ,
+        build_file="//deps/type_safe:build.BUILD" ,
+        sha256="b1286d2b8598cdf6641887fa866c56abad47c464469cbe8002486db3eb8f051c" ,
+        strip_prefix="type_safe-3612e2828b4b4e0d1cc689373e63a6d59d4bfd79" ,
+        urls = [
+            "https://github.com/foonathan/type_safe/archive/3612e2828b4b4e0d1cc689373e63a6d59d4bfd79.tar.gz"
+        ],
+    )
+


### PR DESCRIPTION
I see a [conan](https://github.com/foonathan/cppast/pull/75) build has been in the works.  Would you consider supporting [bazel](https://bazel.build/) upstream?  Bazel has become a popular build system for C++.  For better or worse, it requires you to build your libraries the google way; from source.  Here I've provided a working bazel build for `cppast` that extracts `libclang` from a hermetic toolchain.  It also builds and links `type_safe` since that's a dependency.

The library can be built by running `bazelisk build @cppast//:cppast`.
For now, this PR serves as an example for anyone integrating with bazel.

If we decide to upstream anything, we can add a CI step to ensure bazel compatibility.